### PR TITLE
Turn on LED when dim

### DIFF
--- a/Lab-3-Sketch-Alex-Robertson/Lab-3-Sketch-Alex-Robertson.ino
+++ b/Lab-3-Sketch-Alex-Robertson/Lab-3-Sketch-Alex-Robertson.ino
@@ -1,5 +1,11 @@
 void setup() {
+  // Analog pin 6 (Light Sensor)
   pinMode(A6, INPUT);
+  // Digital pin 4
+  pinMode(4, OUTPUT);
+  // Sets pin 4 to be off by default
+  digitalWrite(4, LOW);
+
   int lightLevel = analogRead(A6);
   Serial.begin(9600);
   Serial.println(lightLevel);
@@ -7,6 +13,8 @@ void setup() {
   if (lightLevel < 100) {
       Serial.println(lightLevel);
       Serial.println("It's really dark!");
+      // Sets digital pin 4 to be on
+      digitalWrite(4, HIGH);
     } else if (lightLevel < 200) {
       Serial.println(lightLevel);
       Serial.println("It's dim in here.");


### PR DESCRIPTION
Turns on digital pin 4 (an LED) whenever the light level is less than 100. Makes sure to turn it off by default. Board still needs to be reset every time.